### PR TITLE
feat(core): change definition of serverlessly protocol

### DIFF
--- a/@serverlessly/core/__tests__/dummies/protocols.ts
+++ b/@serverlessly/core/__tests__/dummies/protocols.ts
@@ -204,315 +204,375 @@ export type DummyProtocolSyncOrAsync = Protocol<
 // Concrete Dummy Protocols
 //000
 export const dummyProtocolSync: DummyProtocolSync = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineSync,
+  name: 'dummyProtocolSync',
+  middlewareEngine: dummyMiddlewareEngineSync,
   serverFactory: dummyProtocolServerFactorySync,
 };
 
 export const dummyProtocol001: DummyProtocol001 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineSync,
+  name: 'dummyProtocol001',
+  middlewareEngine: dummyMiddlewareEngineSync,
   serverFactory: dummyProtocolServerFactory01,
 };
 
 export const dummyProtocol002: DummyProtocol002 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineSync,
+  name: 'dummyProtocol002',
+  middlewareEngine: dummyMiddlewareEngineSync,
   serverFactory: dummyProtocolServerFactory02,
 };
 
 export const dummyProtocol101: DummyProtocol101 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine10,
+  name: 'dummyProtocol101',
+  middlewareEngine: dummyMiddlewareEngine10,
   serverFactory: dummyProtocolServerFactoryAsync,
 };
 
 export const dummyProtocol102: DummyProtocol102 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine10,
+  name: 'dummyProtocol102',
+  middlewareEngine: dummyMiddlewareEngine10,
   serverFactory: dummyProtocolServerFactory12,
 };
 
 //111
 export const dummyProtocolAsync: DummyProtocolAsync = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineAsync,
+  name: 'dummyProtocolAsync',
+  middlewareEngine: dummyMiddlewareEngineAsync,
   serverFactory: dummyProtocolServerFactoryAsync,
 };
 
 export const dummyProtocol112: DummyProtocol112 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineAsync,
+  name: 'dummyProtocol112',
+  middlewareEngine: dummyMiddlewareEngineAsync,
   serverFactory: dummyProtocolServerFactory12,
 };
 
 export const dummyProtocol121: DummyProtocol121 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine12,
+  name: 'dummyProtocol121',
+  middlewareEngine: dummyMiddlewareEngine12,
   serverFactory: dummyProtocolServerFactoryAsync,
 };
 
 export const dummyProtocol122: DummyProtocol122 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine12,
+  name: 'dummyProtocol122',
+  middlewareEngine: dummyMiddlewareEngine12,
   serverFactory: dummyProtocolServerFactory12,
 };
 
 export const dummyProtocol201: DummyProtocol201 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine20,
+  name: 'dummyProtocol201',
+  middlewareEngine: dummyMiddlewareEngine20,
   serverFactory: dummyProtocolServerFactory21,
 };
 
 export const dummyProtocol202: DummyProtocol202 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine20,
+  name: 'dummyProtocol202',
+  middlewareEngine: dummyMiddlewareEngine20,
   serverFactory: dummyProtocolServerFactorySyncOrAsync,
 };
 
 export const dummyProtocol211: DummyProtocol211 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine21,
+  name: 'dummyProtocol211',
+  middlewareEngine: dummyMiddlewareEngine21,
   serverFactory: dummyProtocolServerFactory21,
 };
 
 export const dummyProtocol212: DummyProtocol212 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine21,
+  name: 'dummyProtocol212',
+  middlewareEngine: dummyMiddlewareEngine21,
   serverFactory: dummyProtocolServerFactorySyncOrAsync,
 };
 
 export const dummyProtocol221: DummyProtocol221 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineSyncOrAsync,
+  name: 'dummyProtocol221',
+  middlewareEngine: dummyMiddlewareEngineSyncOrAsync,
   serverFactory: dummyProtocolServerFactory21,
 };
 
 //222
 export const dummyProtocolSyncOrAsync: DummyProtocolSyncOrAsync = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineSyncOrAsync,
+  name: 'dummyProtocolSyncOrAsync',
+  middlewareEngine: dummyMiddlewareEngineSyncOrAsync,
   serverFactory: dummyProtocolServerFactorySyncOrAsync,
 };
 
-// Faulty Dummy Protocols with Faulty defaultMiddlewareEngine (ME suffix)
+// Faulty Dummy Protocols with Faulty middlewareEngine (ME suffix)
 //000
 export const faultyProtocolSyncME: DummyProtocolSync = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineSync,
+  name: 'faultyProtocolSyncME',
+  middlewareEngine: faultyMiddlewareEngineSync,
   serverFactory: dummyProtocolServerFactorySync,
 };
 
 export const faultyProtocol001ME: DummyProtocol001 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineSync,
+  name: 'faultyProtocol001ME',
+  middlewareEngine: faultyMiddlewareEngineSync,
   serverFactory: dummyProtocolServerFactory01,
 };
 
 export const faultyProtocol002ME: DummyProtocol002 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineSync,
+  name: 'faultyProtocol002ME',
+  middlewareEngine: faultyMiddlewareEngineSync,
   serverFactory: dummyProtocolServerFactory02,
 };
 
 export const faultyProtocol101ME: DummyProtocol101 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine10,
+  name: 'faultyProtocol101ME',
+  middlewareEngine: faultyMiddlewareEngine10,
   serverFactory: dummyProtocolServerFactoryAsync,
 };
 
 export const faultyProtocol102ME: DummyProtocol102 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine10,
+  name: 'faultyProtocol102ME',
+  middlewareEngine: faultyMiddlewareEngine10,
   serverFactory: dummyProtocolServerFactory12,
 };
 
 //111
 export const faultyProtocolAsyncME: DummyProtocolAsync = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineAsync,
+  name: 'faultyProtocolAsyncME',
+  middlewareEngine: faultyMiddlewareEngineAsync,
   serverFactory: dummyProtocolServerFactoryAsync,
 };
 
 export const faultyProtocol112ME: DummyProtocol112 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineAsync,
+  name: 'faultyProtocol112ME',
+  middlewareEngine: faultyMiddlewareEngineAsync,
   serverFactory: dummyProtocolServerFactory12,
 };
 
 export const faultyProtocol121ME: DummyProtocol121 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine12,
+  name: 'faultyProtocol121ME',
+  middlewareEngine: faultyMiddlewareEngine12,
   serverFactory: dummyProtocolServerFactoryAsync,
 };
 
 export const faultyProtocol122ME: DummyProtocol122 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine12,
+  name: 'faultyProtocol122ME',
+  middlewareEngine: faultyMiddlewareEngine12,
   serverFactory: dummyProtocolServerFactory12,
 };
 
 export const faultyProtocol201ME: DummyProtocol201 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine20,
+  name: 'faultyProtocol201ME',
+  middlewareEngine: faultyMiddlewareEngine20,
   serverFactory: dummyProtocolServerFactory21,
 };
 
 export const faultyProtocol202ME: DummyProtocol202 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine20,
+  name: 'faultyProtocol202ME',
+  middlewareEngine: faultyMiddlewareEngine20,
   serverFactory: dummyProtocolServerFactorySyncOrAsync,
 };
 
 export const faultyProtocol211ME: DummyProtocol211 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine21,
+  name: 'faultyProtocol211ME',
+  middlewareEngine: faultyMiddlewareEngine21,
   serverFactory: dummyProtocolServerFactory21,
 };
 
 export const faultyProtocol212ME: DummyProtocol212 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine21,
+  name: 'faultyProtocol212ME',
+  middlewareEngine: faultyMiddlewareEngine21,
   serverFactory: dummyProtocolServerFactorySyncOrAsync,
 };
 
 export const faultyProtocol221ME: DummyProtocol221 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineSyncOrAsync,
+  name: 'faultyProtocol221ME',
+  middlewareEngine: faultyMiddlewareEngineSyncOrAsync,
   serverFactory: dummyProtocolServerFactory21,
 };
 
 //222
 export const faultyProtocolSyncOrAsyncME: DummyProtocolSyncOrAsync = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineSyncOrAsync,
+  name: 'faultyProtocolSyncOrAsyncME',
+  middlewareEngine: faultyMiddlewareEngineSyncOrAsync,
   serverFactory: dummyProtocolServerFactorySyncOrAsync,
 };
 
 // Faulty Dummy Protocols with Faulty serverFactory (SF suffix)
 //000
 export const faultyProtocolSyncSF: DummyProtocolSync = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineSync,
+  name: 'faultyProtocolSyncSF',
+  middlewareEngine: dummyMiddlewareEngineSync,
   serverFactory: faultyProtocolServerFactorySync,
 };
 
 export const faultyProtocol001SF: DummyProtocol001 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineSync,
+  name: 'faultyProtocol001SF',
+  middlewareEngine: dummyMiddlewareEngineSync,
   serverFactory: faultyProtocolServerFactory01,
 };
 
 export const faultyProtocol002SF: DummyProtocol002 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineSync,
+  name: 'faultyProtocol002SF',
+  middlewareEngine: dummyMiddlewareEngineSync,
   serverFactory: faultyProtocolServerFactory02,
 };
 
 export const faultyProtocol101SF: DummyProtocol101 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine10,
+  name: 'faultyProtocol101SF',
+  middlewareEngine: dummyMiddlewareEngine10,
   serverFactory: faultyProtocolServerFactoryAsync,
 };
 
 export const faultyProtocol102SF: DummyProtocol102 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine10,
+  name: 'faultyProtocol102SF',
+  middlewareEngine: dummyMiddlewareEngine10,
   serverFactory: faultyProtocolServerFactory12,
 };
 
 //111
 export const faultyProtocolAsyncSF: DummyProtocolAsync = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineAsync,
+  name: 'faultyProtocolAsyncSF',
+  middlewareEngine: dummyMiddlewareEngineAsync,
   serverFactory: faultyProtocolServerFactoryAsync,
 };
 
 export const faultyProtocol112SF: DummyProtocol112 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineAsync,
+  name: 'faultyProtocol112SF',
+  middlewareEngine: dummyMiddlewareEngineAsync,
   serverFactory: faultyProtocolServerFactory12,
 };
 
 export const faultyProtocol121SF: DummyProtocol121 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine12,
+  name: 'faultyProtocol121SF',
+  middlewareEngine: dummyMiddlewareEngine12,
   serverFactory: faultyProtocolServerFactoryAsync,
 };
 
 export const faultyProtocol122SF: DummyProtocol122 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine12,
+  name: 'faultyProtocol122SF',
+  middlewareEngine: dummyMiddlewareEngine12,
   serverFactory: faultyProtocolServerFactory12,
 };
 
 export const faultyProtocol201SF: DummyProtocol201 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine20,
+  name: 'faultyProtocol201SF',
+  middlewareEngine: dummyMiddlewareEngine20,
   serverFactory: faultyProtocolServerFactory21,
 };
 
 export const faultyProtocol202SF: DummyProtocol202 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine20,
+  name: 'faultyProtocol202SF',
+  middlewareEngine: dummyMiddlewareEngine20,
   serverFactory: faultyProtocolServerFactorySyncOrAsync,
 };
 
 export const faultyProtocol211SF: DummyProtocol211 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine21,
+  name: 'faultyProtocol211SF',
+  middlewareEngine: dummyMiddlewareEngine21,
   serverFactory: faultyProtocolServerFactory21,
 };
 
 export const faultyProtocol212SF: DummyProtocol212 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngine21,
+  name: 'faultyProtocol212SF',
+  middlewareEngine: dummyMiddlewareEngine21,
   serverFactory: faultyProtocolServerFactorySyncOrAsync,
 };
 
 export const faultyProtocol221SF: DummyProtocol221 = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineSyncOrAsync,
+  name: 'faultyProtocol221SF',
+  middlewareEngine: dummyMiddlewareEngineSyncOrAsync,
   serverFactory: faultyProtocolServerFactory21,
 };
 
 //222
 export const faultyProtocolSyncOrAsyncSF: DummyProtocolSyncOrAsync = {
-  defaultMiddlewareEngine: dummyMiddlewareEngineSyncOrAsync,
+  name: 'faultyProtocolSyncOrAsyncSF',
+  middlewareEngine: dummyMiddlewareEngineSyncOrAsync,
   serverFactory: faultyProtocolServerFactorySyncOrAsync,
 };
 
-// Faulty Dummy Protocols with both Faulty defaultMiddlewareEngine & serverFactory (B suffix)
+// Faulty Dummy Protocols with both Faulty middlewareEngine & serverFactory (B suffix)
 //000
 export const faultyProtocolSyncB: DummyProtocolSync = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineSync,
+  name: 'faultyProtocolSyncB',
+  middlewareEngine: faultyMiddlewareEngineSync,
   serverFactory: faultyProtocolServerFactorySync,
 };
 
 export const faultyProtocol001B: DummyProtocol001 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineSync,
+  name: 'faultyProtocol001B',
+  middlewareEngine: faultyMiddlewareEngineSync,
   serverFactory: faultyProtocolServerFactory01,
 };
 
 export const faultyProtocol002B: DummyProtocol002 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineSync,
+  name: 'faultyProtocol002B',
+  middlewareEngine: faultyMiddlewareEngineSync,
   serverFactory: faultyProtocolServerFactory02,
 };
 
 export const faultyProtocol101B: DummyProtocol101 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine10,
+  name: 'faultyProtocol101B',
+  middlewareEngine: faultyMiddlewareEngine10,
   serverFactory: faultyProtocolServerFactoryAsync,
 };
 
 export const faultyProtocol102B: DummyProtocol102 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine10,
+  name: 'faultyProtocol102B',
+  middlewareEngine: faultyMiddlewareEngine10,
   serverFactory: faultyProtocolServerFactory12,
 };
 
 //111
 export const faultyProtocolAsyncB: DummyProtocolAsync = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineAsync,
+  name: 'faultyProtocolAsyncB',
+  middlewareEngine: faultyMiddlewareEngineAsync,
   serverFactory: faultyProtocolServerFactoryAsync,
 };
 
 export const faultyProtocol112B: DummyProtocol112 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineAsync,
+  name: 'faultyProtocol112B',
+  middlewareEngine: faultyMiddlewareEngineAsync,
   serverFactory: faultyProtocolServerFactory12,
 };
 
 export const faultyProtocol121B: DummyProtocol121 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine12,
+  name: 'faultyProtocol121B',
+  middlewareEngine: faultyMiddlewareEngine12,
   serverFactory: faultyProtocolServerFactoryAsync,
 };
 
 export const faultyProtocol122B: DummyProtocol122 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine12,
+  name: 'faultyProtocol122B',
+  middlewareEngine: faultyMiddlewareEngine12,
   serverFactory: faultyProtocolServerFactory12,
 };
 
 export const faultyProtocol201B: DummyProtocol201 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine20,
+  name: 'faultyProtocol201B',
+  middlewareEngine: faultyMiddlewareEngine20,
   serverFactory: faultyProtocolServerFactory21,
 };
 
 export const faultyProtocol202B: DummyProtocol202 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine20,
+  name: 'faultyProtocol202B',
+  middlewareEngine: faultyMiddlewareEngine20,
   serverFactory: faultyProtocolServerFactorySyncOrAsync,
 };
 
 export const faultyProtocol211B: DummyProtocol211 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine21,
+  name: 'faultyProtocol211B',
+  middlewareEngine: faultyMiddlewareEngine21,
   serverFactory: faultyProtocolServerFactory21,
 };
 
 export const faultyProtocol212B: DummyProtocol212 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngine21,
+  name: 'faultyProtocol212B',
+  middlewareEngine: faultyMiddlewareEngine21,
   serverFactory: faultyProtocolServerFactorySyncOrAsync,
 };
 
 export const faultyProtocol221B: DummyProtocol221 = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineSyncOrAsync,
+  name: 'faultyProtocol221B',
+  middlewareEngine: faultyMiddlewareEngineSyncOrAsync,
   serverFactory: faultyProtocolServerFactory21,
 };
 
 //222
 export const faultyProtocolSyncOrAsyncB: DummyProtocolSyncOrAsync = {
-  defaultMiddlewareEngine: faultyMiddlewareEngineSyncOrAsync,
+  name: 'faultyProtocolSyncOrAsyncB',
+  middlewareEngine: faultyMiddlewareEngineSyncOrAsync,
   serverFactory: faultyProtocolServerFactorySyncOrAsync,
 };

--- a/@serverlessly/core/lib/protocol.ts
+++ b/@serverlessly/core/lib/protocol.ts
@@ -21,10 +21,11 @@ export type ProtocolServerFactory<
  * A new Serverlessly `Protocol` needs to implement this interface
  */
 export interface Protocol<TProtocolContext, TMiddleware, TProtocolServer> {
+  name: string;
   /**
-   * `Middleware Engine` available with Serverlessly `Protocol` by default
+   * `Middleware Engine` available with Serverlessly `Protocol`
    */
-  defaultMiddlewareEngine: MiddlewareEngine<TProtocolContext, TMiddleware>;
+  middlewareEngine: MiddlewareEngine<TProtocolContext, TMiddleware>;
   /**
    * `Protocol Server Factory` which can create `Protocol Server` capable of running a Serverlessly microservice on self-managed infrastructure
    */

--- a/@serverlessly/core/lib/protocol.ts
+++ b/@serverlessly/core/lib/protocol.ts
@@ -21,6 +21,9 @@ export type ProtocolServerFactory<
  * A new Serverlessly `Protocol` needs to implement this interface
  */
 export interface Protocol<TProtocolContext, TMiddleware, TProtocolServer> {
+  /**
+   * name of the `Protocol`
+   */
   name: string;
   /**
    * `Middleware Engine` available with Serverlessly `Protocol`

--- a/@serverlessly/core/lib/serverlessly.ts
+++ b/@serverlessly/core/lib/serverlessly.ts
@@ -117,7 +117,7 @@ export interface ServerlesslyProps<
   /**
    * `Middleware Engine` which processes middlewares
    *
-   * @defaultValue `protocol.defaultMiddlewareEngine`
+   * @defaultValue `protocol.middlewareEngine`
    */
   middlewareEngine?: MiddlewareEngine<TProtocolContext, TMiddleware>;
 }
@@ -187,8 +187,14 @@ export class Serverlessly<
   ) {
     super();
     this.middlewareEngine =
-      props.middlewareEngine || props.protocol.defaultMiddlewareEngine;
+      props.middlewareEngine || props.protocol.middlewareEngine;
     this.protocolServerFactory = props.protocol.serverFactory;
+    setImmediate(() => {
+      this.emit(
+        'LOG',
+        `Serverlessly microservice initialized successfully with ${props.protocol.name} protocol.`
+      );
+    });
   }
 
   /**


### PR DESCRIPTION
<!-- Read Pull Request guideline: https://github.com/ServerlesslyStack/Serverlessly/blob/main/CONTRIBUTING.md#pull-request -->
<!-- Start by copying & pasting 🚧 (construction emoji) as a suffix of the title above. -->
<!-- Explain below what this Pull Request is all about. What's the motivation? What problem does it solve? -->

This Pull Request:

- adds `name` field to `Protocol` which is meant for humans.
- renames `Protocol.defaultMiddlewareEngine` to `protocol.middlewareEngine`.
- edits Serverlessly constructor to emit logs about successful initialization with `Protocol.name`. The log is emitted just after the event loop finishes initializing Serverlessly.

<!-- If this Pull Request fixes a bug, write "Fixes #123" without quotes where 123 is issue number. If an issue doesn't exist for the bug, create that first. -->
<!-- If this Pull Request implements a feature, write "Closes #123" without quotes where 123 is issue number. -->

<!-- If this Pull Request introduces BREAKING CHANGES, please uncomment the following line: -->
<!-- This PR introduces BREAKING CHANGES. -->

<!-- You must tick appropriate checkboxes below if applicable. To tick, replace [ ] with [x]. -->
- [x] I have read [CONTRIBUTING guide](../CONTRIBUTING.md).
- [x] I have added necessary tests.
- [x] I have added necessary docs.
- [x] I have run `yarn test && yarn lint && yarn format`.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
