### PR TITLE
feat(core): allow protocol server configuration

### DIFF
--- a/@serverlessly/core/__tests__/dummies/protocol-server-factories.ts
+++ b/@serverlessly/core/__tests__/dummies/protocol-server-factories.ts
@@ -16,127 +16,143 @@ import {
 // 00
 export type DummyProtocolServerFactorySync = ProtocolServerFactory<
   DummyProtocolContextSync,
-  DummyProtocolServerSync
+  DummyProtocolServerSync,
+  string
 >;
 export type DummyProtocolServerFactory01 = ProtocolServerFactory<
   DummyProtocolContextSync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type DummyProtocolServerFactory02 = ProtocolServerFactory<
   DummyProtocolContextSync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type DummyProtocolServerFactory10 = ProtocolServerFactory<
 //   DummyProtocolContextAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 // 11
 export type DummyProtocolServerFactoryAsync = ProtocolServerFactory<
   DummyProtocolContextAsync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type DummyProtocolServerFactory12 = ProtocolServerFactory<
   DummyProtocolContextAsync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type DummyProtocolServerFactory20 = ProtocolServerFactory<
 //   DummyProtocolContextSyncOrAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 export type DummyProtocolServerFactory21 = ProtocolServerFactory<
   DummyProtocolContextSyncOrAsync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 // 22
 export type DummyProtocolServerFactorySyncOrAsync = ProtocolServerFactory<
   DummyProtocolContextSyncOrAsync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 
 // Concrete Protocol Server Factories
 export const dummyProtocolServerFactorySync: DummyProtocolServerFactorySync = (
-  protocolContext: DummyProtocolContextSync
-) => new DummyProtocolServerSync(protocolContext);
+  prefix: string
+) => (protocolContext: DummyProtocolContextSync) =>
+  new DummyProtocolServerSync(prefix, protocolContext);
 
 export const dummyProtocolServerFactory01: DummyProtocolServerFactory01 = (
-  protocolContext: DummyProtocolContextSync
-) => new DummyProtocolServerAsync(protocolContext);
+  prefix: string
+) => (protocolContext: DummyProtocolContextSync) =>
+  new DummyProtocolServerAsync(prefix, protocolContext);
 
 export const dummyProtocolServerFactory02: DummyProtocolServerFactory02 = (
-  protocolContext: DummyProtocolContextSync
-) => new DummyProtocolServerSyncOrAsync(protocolContext);
+  prefix: string
+) => (protocolContext: DummyProtocolContextSync) =>
+  new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
 
 export const dummyProtocolServerFactoryAsync: DummyProtocolServerFactoryAsync = (
-  protocolContext: DummyProtocolContextAsync
-) => new DummyProtocolServerAsync(protocolContext);
+  prefix: string
+) => (protocolContext: DummyProtocolContextAsync) =>
+  new DummyProtocolServerAsync(prefix, protocolContext);
 
 export const dummyProtocolServerFactory12: DummyProtocolServerFactory12 = (
-  protocolContext: DummyProtocolContextAsync
-) => new DummyProtocolServerSyncOrAsync(protocolContext);
+  prefix: string
+) => (protocolContext: DummyProtocolContextAsync) =>
+  new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
 
 export const dummyProtocolServerFactory21: DummyProtocolServerFactory21 = (
-  protocolContext: DummyProtocolContextSyncOrAsync
-) => new DummyProtocolServerAsync(protocolContext);
+  prefix: string
+) => (protocolContext: DummyProtocolContextSyncOrAsync) =>
+  new DummyProtocolServerAsync(prefix, protocolContext);
 
 export const dummyProtocolServerFactorySyncOrAsync: DummyProtocolServerFactorySyncOrAsync = (
-  protocolContext: DummyProtocolContextSyncOrAsync
-) => new DummyProtocolServerSyncOrAsync(protocolContext);
+  prefix: string
+) => (protocolContext: DummyProtocolContextSyncOrAsync) =>
+  new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
 
 // Faulty Protocol Server Factories
 export const faultyProtocolServerFactorySync: DummyProtocolServerFactorySync = (
-  protocolContext: DummyProtocolContextSync
-) => {
+  prefix: string
+) => (protocolContext: DummyProtocolContextSync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerSync(protocolContext);
+  return new DummyProtocolServerSync(prefix, protocolContext);
 };
 
 export const faultyProtocolServerFactory01: DummyProtocolServerFactory01 = (
-  protocolContext: DummyProtocolContextSync
-) => {
+  prefix: string
+) => (protocolContext: DummyProtocolContextSync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerAsync(protocolContext);
+  return new DummyProtocolServerAsync(prefix, protocolContext);
 };
 
 export const faultyProtocolServerFactory02: DummyProtocolServerFactory02 = (
-  protocolContext: DummyProtocolContextSync
-) => {
+  prefix: string
+) => (protocolContext: DummyProtocolContextSync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerSyncOrAsync(protocolContext);
+  return new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
 };
 
 export const faultyProtocolServerFactoryAsync: DummyProtocolServerFactoryAsync = (
-  protocolContext: DummyProtocolContextAsync
-) => {
+  prefix: string
+) => (protocolContext: DummyProtocolContextAsync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerAsync(protocolContext);
+  return new DummyProtocolServerAsync(prefix, protocolContext);
 };
 
 export const faultyProtocolServerFactory12: DummyProtocolServerFactory12 = (
-  protocolContext: DummyProtocolContextAsync
-) => {
+  prefix: string
+) => (protocolContext: DummyProtocolContextAsync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerSyncOrAsync(protocolContext);
+  return new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
 };
 
 export const faultyProtocolServerFactory21: DummyProtocolServerFactory21 = (
-  protocolContext: DummyProtocolContextSyncOrAsync
-) => {
+  prefix: string
+) => (protocolContext: DummyProtocolContextSyncOrAsync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerAsync(protocolContext);
+  return new DummyProtocolServerAsync(prefix, protocolContext);
 };
 
 export const faultyProtocolServerFactorySyncOrAsync: DummyProtocolServerFactorySyncOrAsync = (
-  protocolContext: DummyProtocolContextSyncOrAsync
-) => {
+  prefix: string
+) => (protocolContext: DummyProtocolContextSyncOrAsync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerSyncOrAsync(protocolContext);
+  return new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
 };

--- a/@serverlessly/core/__tests__/dummies/protocol-server-factories.ts
+++ b/@serverlessly/core/__tests__/dummies/protocol-server-factories.ts
@@ -66,93 +66,93 @@ export type DummyProtocolServerFactorySyncOrAsync = ProtocolServerFactory<
 
 // Concrete Protocol Server Factories
 export const dummyProtocolServerFactorySync: DummyProtocolServerFactorySync = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextSync) =>
-  new DummyProtocolServerSync(prefix, protocolContext);
+  new DummyProtocolServerSync(protocolContext, prefix);
 
 export const dummyProtocolServerFactory01: DummyProtocolServerFactory01 = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextSync) =>
-  new DummyProtocolServerAsync(prefix, protocolContext);
+  new DummyProtocolServerAsync(protocolContext, prefix);
 
 export const dummyProtocolServerFactory02: DummyProtocolServerFactory02 = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextSync) =>
-  new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
+  new DummyProtocolServerSyncOrAsync(protocolContext, prefix);
 
 export const dummyProtocolServerFactoryAsync: DummyProtocolServerFactoryAsync = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextAsync) =>
-  new DummyProtocolServerAsync(prefix, protocolContext);
+  new DummyProtocolServerAsync(protocolContext, prefix);
 
 export const dummyProtocolServerFactory12: DummyProtocolServerFactory12 = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextAsync) =>
-  new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
+  new DummyProtocolServerSyncOrAsync(protocolContext, prefix);
 
 export const dummyProtocolServerFactory21: DummyProtocolServerFactory21 = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextSyncOrAsync) =>
-  new DummyProtocolServerAsync(prefix, protocolContext);
+  new DummyProtocolServerAsync(protocolContext, prefix);
 
 export const dummyProtocolServerFactorySyncOrAsync: DummyProtocolServerFactorySyncOrAsync = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextSyncOrAsync) =>
-  new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
+  new DummyProtocolServerSyncOrAsync(protocolContext, prefix);
 
 // Faulty Protocol Server Factories
 export const faultyProtocolServerFactorySync: DummyProtocolServerFactorySync = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextSync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerSync(prefix, protocolContext);
+  return new DummyProtocolServerSync(protocolContext, prefix);
 };
 
 export const faultyProtocolServerFactory01: DummyProtocolServerFactory01 = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextSync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerAsync(prefix, protocolContext);
+  return new DummyProtocolServerAsync(protocolContext, prefix);
 };
 
 export const faultyProtocolServerFactory02: DummyProtocolServerFactory02 = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextSync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
+  return new DummyProtocolServerSyncOrAsync(protocolContext, prefix);
 };
 
 export const faultyProtocolServerFactoryAsync: DummyProtocolServerFactoryAsync = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextAsync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerAsync(prefix, protocolContext);
+  return new DummyProtocolServerAsync(protocolContext, prefix);
 };
 
 export const faultyProtocolServerFactory12: DummyProtocolServerFactory12 = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextAsync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
+  return new DummyProtocolServerSyncOrAsync(protocolContext, prefix);
 };
 
 export const faultyProtocolServerFactory21: DummyProtocolServerFactory21 = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextSyncOrAsync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerAsync(prefix, protocolContext);
+  return new DummyProtocolServerAsync(protocolContext, prefix);
 };
 
 export const faultyProtocolServerFactorySyncOrAsync: DummyProtocolServerFactorySyncOrAsync = (
-  prefix: string
+  prefix?: string
 ) => (protocolContext: DummyProtocolContextSyncOrAsync) => {
   const array = [];
   array.length = -1; // Created "RangeError: Invalid array length"
-  return new DummyProtocolServerSyncOrAsync(prefix, protocolContext);
+  return new DummyProtocolServerSyncOrAsync(protocolContext, prefix);
 };

--- a/@serverlessly/core/__tests__/dummies/protocol-servers.ts
+++ b/@serverlessly/core/__tests__/dummies/protocol-servers.ts
@@ -7,22 +7,22 @@ import {
 // Dummy Protocol Servers
 export class DummyProtocolServerSync {
   constructor(
-    private prefix: string,
-    private protocolContext: DummyProtocolContextSync
+    private protocolContext: DummyProtocolContextSync,
+    private prefix?: string
   ) {}
 }
 export class DummyProtocolServerAsync {
   constructor(
-    private prefix: string,
     private protocolContext:
       | DummyProtocolContextAsync
       | DummyProtocolContextSync
-      | DummyProtocolContextSyncOrAsync
+      | DummyProtocolContextSyncOrAsync,
+    private prefix?: string
   ) {}
 }
 export class DummyProtocolServerSyncOrAsync {
   constructor(
-    private prefix: string,
-    private protocolContext: DummyProtocolContextSyncOrAsync
+    private protocolContext: DummyProtocolContextSyncOrAsync,
+    private prefix?: string
   ) {}
 }

--- a/@serverlessly/core/__tests__/dummies/protocol-servers.ts
+++ b/@serverlessly/core/__tests__/dummies/protocol-servers.ts
@@ -6,10 +6,14 @@ import {
 
 // Dummy Protocol Servers
 export class DummyProtocolServerSync {
-  constructor(private protocolContext: DummyProtocolContextSync) {}
+  constructor(
+    private prefix: string,
+    private protocolContext: DummyProtocolContextSync
+  ) {}
 }
 export class DummyProtocolServerAsync {
   constructor(
+    private prefix: string,
     private protocolContext:
       | DummyProtocolContextAsync
       | DummyProtocolContextSync
@@ -17,5 +21,8 @@ export class DummyProtocolServerAsync {
   ) {}
 }
 export class DummyProtocolServerSyncOrAsync {
-  constructor(private protocolContext: DummyProtocolContextSyncOrAsync) {}
+  constructor(
+    private prefix: string,
+    private protocolContext: DummyProtocolContextSyncOrAsync
+  ) {}
 }

--- a/@serverlessly/core/__tests__/dummies/protocols.ts
+++ b/@serverlessly/core/__tests__/dummies/protocols.ts
@@ -54,151 +54,178 @@ import {
 export type DummyProtocolSync = Protocol<
   DummyProtocolContextSync,
   DummyMiddlewareSync,
-  DummyProtocolServerSync
+  DummyProtocolServerSync,
+  string
 >;
 export type DummyProtocol001 = Protocol<
   DummyProtocolContextSync,
   DummyMiddlewareSync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type DummyProtocol002 = Protocol<
   DummyProtocolContextSync,
   DummyMiddlewareSync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type DummyProtocol010 = Protocol<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 // An Impossibility!!!
 // export type DummyProtocol011 = Protocol<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareAsync,
-//   DummyProtocolServerAsync
+//   DummyProtocolServerAsync,
+//   string
 // >;
 // An Impossibility!!!
 // export type DummyProtocol012 = Protocol<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareAsync,
-//   DummyProtocolServerSyncOrAsync
+//   DummyProtocolServerSyncOrAsync,
+//   string
 // >;
 // An Impossibility!!!
 // export type DummyProtocol020 = Protocol<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareSyncOrAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 // An Impossibility!!!
 // export type DummyProtocol021 = Protocol<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareSyncOrAsync,
-//   DummyProtocolServerAsync
+//   DummyProtocolServerAsync,
+//   string
 // >;
 // An Impossibility!!!
 // export type DummyProtocol022 = Protocol<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareSyncOrAsync,
-//   DummyProtocolServerSyncOrAsync
+//   DummyProtocolServerSyncOrAsync,
+//   string
 // >;
 // An Impossibility!!!
 // export type DummyProtocol100 = Protocol<
 //   DummyProtocolContextAsync,
 //   DummyMiddlewareSync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 export type DummyProtocol101 = Protocol<
   DummyProtocolContextAsync,
   DummyMiddlewareSync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type DummyProtocol102 = Protocol<
   DummyProtocolContextAsync,
   DummyMiddlewareSync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type DummyProtocol110 = Protocol<
 //   DummyProtocolContextAsync,
 //   DummyMiddlewareAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 //111
 export type DummyProtocolAsync = Protocol<
   DummyProtocolContextAsync,
   DummyMiddlewareAsync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type DummyProtocol112 = Protocol<
   DummyProtocolContextAsync,
   DummyMiddlewareAsync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type DummyProtocol120 = Protocol<
 //   DummyProtocolContextAsync,
 //   DummyMiddlewareSyncOrAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 export type DummyProtocol121 = Protocol<
   DummyProtocolContextAsync,
   DummyMiddlewareSyncOrAsync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type DummyProtocol122 = Protocol<
   DummyProtocolContextAsync,
   DummyMiddlewareSyncOrAsync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type DummyProtocol200 = Protocol<
 //   DummyProtocolContextSyncOrAsync,
 //   DummyMiddlewareSync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 export type DummyProtocol201 = Protocol<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareSync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type DummyProtocol202 = Protocol<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareSync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type DummyProtocol210 = Protocol<
 //   DummyProtocolContextSyncOrAsync,
 //   DummyMiddlewareAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 export type DummyProtocol211 = Protocol<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareAsync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type DummyProtocol212 = Protocol<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareAsync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type DummyProtocol220 = Protocol<
 //   DummyProtocolContextSyncOrAsync,
 //   DummyMiddlewareSyncOrAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 export type DummyProtocol221 = Protocol<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareSyncOrAsync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 // 222
 export type DummyProtocolSyncOrAsync = Protocol<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareSyncOrAsync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 
 // Concrete Dummy Protocols

--- a/@serverlessly/core/__tests__/dummies/serverlessly.ts
+++ b/@serverlessly/core/__tests__/dummies/serverlessly.ts
@@ -22,149 +22,176 @@ import {
 export type ServerlesslySync = Serverlessly<
   DummyProtocolContextSync,
   DummyMiddlewareSync,
-  DummyProtocolServerSync
+  DummyProtocolServerSync,
+  string
 >;
 export type Serverlessly001 = Serverlessly<
   DummyProtocolContextSync,
   DummyMiddlewareSync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type Serverlessly002 = Serverlessly<
   DummyProtocolContextSync,
   DummyMiddlewareSync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type Serverlessly010 = Serverlessly<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 // An Impossibility!!!
 // export type Serverlessly011 = Serverlessly<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareAsync,
-//   DummyProtocolServerAsync
+//   DummyProtocolServerAsync,
+//   string
 // >;
 // An Impossibility!!!
 // export type Serverlessly012 = Serverlessly<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareAsync,
-//   DummyProtocolServerSyncOrAsync
+//   DummyProtocolServerSyncOrAsync,
+//   string
 // >;
 // An Impossibility!!!
 // export type Serverlessly020 = Serverlessly<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareSyncOrAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 // An Impossibility!!!
 // export type Serverlessly021 = Serverlessly<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareSyncOrAsync,
-//   DummyProtocolServerAsync
+//   DummyProtocolServerAsync,
+//   string
 // >;
 // An Impossibility!!!
 // export type Serverlessly022 = Serverlessly<
 //   DummyProtocolContextSync,
 //   DummyMiddlewareSyncOrAsync,
-//   DummyProtocolServerSyncOrAsync
+//   DummyProtocolServerSyncOrAsync,
+//   string
 // >;
 // An Impossibility!!!
 // export type Serverlessly100 = Serverlessly<
 //   DummyProtocolContextAsync,
 //   DummyMiddlewareSync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 export type Serverlessly101 = Serverlessly<
   DummyProtocolContextAsync,
   DummyMiddlewareSync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type Serverlessly102 = Serverlessly<
   DummyProtocolContextAsync,
   DummyMiddlewareSync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type Serverlessly110 = Serverlessly<
 //   DummyProtocolContextAsync,
 //   DummyMiddlewareAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 //111
 export type ServerlesslyAsync = Serverlessly<
   DummyProtocolContextAsync,
   DummyMiddlewareAsync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type Serverlessly112 = Serverlessly<
   DummyProtocolContextAsync,
   DummyMiddlewareAsync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type Serverlessly120 = Serverlessly<
 //   DummyProtocolContextAsync,
 //   DummyMiddlewareSyncOrAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 export type Serverlessly121 = Serverlessly<
   DummyProtocolContextAsync,
   DummyMiddlewareSyncOrAsync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type Serverlessly122 = Serverlessly<
   DummyProtocolContextAsync,
   DummyMiddlewareSyncOrAsync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type Serverlessly200 = Serverlessly<
 //   DummyProtocolContextSyncOrAsync,
 //   DummyMiddlewareSync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 export type Serverlessly201 = Serverlessly<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareSync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type Serverlessly202 = Serverlessly<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareSync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type Serverlessly210 = Serverlessly<
 //   DummyProtocolContextSyncOrAsync,
 //   DummyMiddlewareAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 export type Serverlessly211 = Serverlessly<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareAsync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 export type Serverlessly212 = Serverlessly<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareAsync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;
 // An Impossibility!!!
 // export type Serverlessly220 = Serverlessly<
 //   DummyProtocolContextSyncOrAsync,
 //   DummyMiddlewareSyncOrAsync,
-//   DummyProtocolServerSync
+//   DummyProtocolServerSync,
+//   string
 // >;
 export type Serverlessly221 = Serverlessly<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareSyncOrAsync,
-  DummyProtocolServerAsync
+  DummyProtocolServerAsync,
+  string
 >;
 // 222
 export type ServerlesslySyncOrAsync = Serverlessly<
   DummyProtocolContextSyncOrAsync,
   DummyMiddlewareSyncOrAsync,
-  DummyProtocolServerSyncOrAsync
+  DummyProtocolServerSyncOrAsync,
+  string
 >;

--- a/@serverlessly/core/__tests__/protocol.test.ts
+++ b/@serverlessly/core/__tests__/protocol.test.ts
@@ -1,4 +1,40 @@
-import { protocolServerAdapter } from '@serverlessly/core';
+import { Protocol, protocolServerAdapter } from '@serverlessly/core';
+import { dummyMiddlewareEngineSync } from './dummies/middleware-engines';
+import { DummyMiddlewareSync } from './dummies/middlewares';
+import { DummyProtocolContextSync } from './dummies/protocol-contexts';
+import { dummyProtocolServerFactorySync } from './dummies/protocol-server-factories';
+import { DummyProtocolServerSync } from './dummies/protocol-servers';
+
+test('Protocol is initialized successfully', () => {
+  expect<
+    Protocol<
+      DummyProtocolContextSync,
+      DummyMiddlewareSync,
+      DummyProtocolServerSync,
+      string
+    >
+  >(
+    new Protocol({
+      name: 'Dummy Protocol',
+      middlewareEngine: dummyMiddlewareEngineSync,
+      serverFactory: dummyProtocolServerFactorySync,
+    })
+  ).toBeTruthy();
+});
+
+test('Initialized Protocol is correct object', () => {
+  expect(
+    new Protocol({
+      name: 'Dummy Protocol',
+      middlewareEngine: dummyMiddlewareEngineSync,
+      serverFactory: dummyProtocolServerFactorySync,
+    })
+  ).toMatchObject({
+    name: 'Dummy Protocol',
+    middlewareEngine: dummyMiddlewareEngineSync,
+    serverFactory: dummyProtocolServerFactorySync,
+  });
+});
 
 test('protocolServerAdapter is a passthrough Platform Adapter', () => {
   const foo = () => 'Foo';

--- a/@serverlessly/core/__tests__/serverlessly-types.test.ts
+++ b/@serverlessly/core/__tests__/serverlessly-types.test.ts
@@ -125,7 +125,7 @@ describe('ServerlesslySync', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerSync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -198,7 +198,7 @@ describe('Serverlessly001', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -271,7 +271,7 @@ describe('Serverlessly002', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerSyncOrAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -340,7 +340,7 @@ describe('Serverlessly101', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -409,7 +409,7 @@ describe('Serverlessly102', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerSyncOrAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -478,7 +478,7 @@ describe('ServerlesslyAsync', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -547,7 +547,7 @@ describe('Serverlessly112', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerSyncOrAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -616,7 +616,7 @@ describe('Serverlessly121', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -685,7 +685,7 @@ describe('Serverlessly122', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerSyncOrAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -746,7 +746,7 @@ describe('Serverlessly201', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -807,7 +807,7 @@ describe('Serverlessly202', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerSyncOrAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -868,7 +868,7 @@ describe('Serverlessly211', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -929,7 +929,7 @@ describe('Serverlessly212', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerSyncOrAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -990,7 +990,7 @@ describe('Serverlessly221', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 
@@ -1051,7 +1051,7 @@ describe('ServerlesslySyncOrAsync', () => {
 
   test('getServer() returns correct type', () => {
     expect<DummyProtocolServerSyncOrAsync>(
-      serverlessly.pipe(dummyMiddleware).getServer()
+      serverlessly.pipe(dummyMiddleware).getServer('')
     );
   });
 

--- a/@serverlessly/core/__tests__/serverlessly.test.ts
+++ b/@serverlessly/core/__tests__/serverlessly.test.ts
@@ -483,10 +483,16 @@ describe('getServer() Tests', () => {
     unknown,
     [props: HandlerProps<DummyProtocolContextSync, unknown>]
   >;
+  let protocolServerFactorySpy: jest.SpyInstance<unknown, unknown[]>;
 
   beforeEach(() => {
     serverlessly = new Serverlessly({ protocol }).pipe(middlewares[0]);
     getHandlerSpy = jest.spyOn(serverlessly, 'getHandler');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protocolServerFactorySpy = jest.spyOn<any, string>(
+      serverlessly,
+      'protocolServerFactory'
+    );
   });
 
   afterEach(() => {
@@ -494,15 +500,25 @@ describe('getServer() Tests', () => {
   });
 
   test('getServer() calls getHandler() once', () => {
-    serverlessly.getServer();
+    serverlessly.getServer('');
     expect(getHandlerSpy).toBeCalledTimes(1);
   });
 
   test('getServer() calls getHandler() with correct arguments', () => {
-    serverlessly.getServer();
+    serverlessly.getServer('');
     expect(getHandlerSpy).toBeCalledWith({
-      platformAdapter: serverlessly['protocolServerFactory'],
+      platformAdapter: expect.any(Function),
     });
+  });
+
+  test('getServer() calls protocolServerFatory() once', () => {
+    serverlessly.getServer('');
+    expect(protocolServerFactorySpy).toBeCalledTimes(1);
+  });
+
+  test('getServer() calls protocolServerFatory() with correct argument', () => {
+    serverlessly.getServer('Hulk Smash');
+    expect(protocolServerFactorySpy).toBeCalledWith('Hulk Smash');
   });
 });
 

--- a/@serverlessly/core/lib/protocol.ts
+++ b/@serverlessly/core/lib/protocol.ts
@@ -5,22 +5,29 @@ import { PlatformAdapter } from './platform-adapter';
  * Type alias for a `Protocol Server Factory`
  * @typeParam TProtocolContext - Generic type of `Protocol Context`
  * @typeParam TProtocolServer - Generic type of `Protocol Server`
+ * @typeParam TProtocolServerProps - Optional generic type of options used to configure `Protocol Server`
  */
 export type ProtocolServerFactory<
   TProtocolContext,
-  TProtocolServer
-> = PlatformAdapter<TProtocolContext, TProtocolServer>;
+  TProtocolServer,
+  TProtocolServerProps = undefined
+> = (
+  serverOptions?: TProtocolServerProps
+) => PlatformAdapter<TProtocolContext, TProtocolServer>;
 
 /**
- * Interface for a Serverlessly `Protocol`
+ * Represents a Serverlessly `Protocol`
  * @typeParam TProtocolContext - Generic type of `Protocol Context`
  * @typeParam TMiddleware - Generic type of middlewares supported by this `Protocol`
  * @typeParam TProtocolServer - Generic type of `Protocol Server` capable of running a Serverlessly microservice on self-managed infrastructure
- *
- * @remarks
- * A new Serverlessly `Protocol` needs to implement this interface
+ * @typeParam TProtocolServerProps - Optional generic type of options used to configure `Protocol Server`
  */
-export interface Protocol<TProtocolContext, TMiddleware, TProtocolServer> {
+export class Protocol<
+  TProtocolContext,
+  TMiddleware,
+  TProtocolServer,
+  TProtocolServerProps = undefined
+> {
   /**
    * name of the `Protocol`
    */
@@ -32,7 +39,37 @@ export interface Protocol<TProtocolContext, TMiddleware, TProtocolServer> {
   /**
    * `Protocol Server Factory` which can create `Protocol Server` capable of running a Serverlessly microservice on self-managed infrastructure
    */
-  serverFactory: ProtocolServerFactory<TProtocolContext, TProtocolServer>;
+  serverFactory: ProtocolServerFactory<
+    TProtocolContext,
+    TProtocolServer,
+    TProtocolServerProps
+  >;
+
+  /**
+   * Creates a new Serverlessly `Protocol`
+   * @param props - Options used to initialize `Protocol` class
+   *
+   * @example
+   * ```ts
+   * new Protocol({
+   *   name: 'MyCustomProtocol',
+   *   middlewareEngine: myMiddlewareEngine,
+   *   serverFactory: myServerFactory,
+   * });
+   * ```
+   */
+  constructor(
+    props: Protocol<
+      TProtocolContext,
+      TMiddleware,
+      TProtocolServer,
+      TProtocolServerProps
+    >
+  ) {
+    this.name = props.name;
+    this.middlewareEngine = props.middlewareEngine;
+    this.serverFactory = props.serverFactory;
+  }
 }
 
 /**

--- a/@serverlessly/core/lib/serverlessly.ts
+++ b/@serverlessly/core/lib/serverlessly.ts
@@ -20,7 +20,9 @@ export interface Serverlessly<
   TProtocolContext,
   TMiddleware,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  TProtocolServer
+  TProtocolServer,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  TProtocolServerProps = undefined
 > {
   emit(event: ServerlesslyLogsEvent, log: string): boolean;
   emit(event: ServerlesslyErrorEvent, error: Error): boolean;
@@ -104,16 +106,23 @@ export interface Serverlessly<
  * @typeParam TProtocolContext - Generic type of `Protocol Context`
  * @typeParam TMiddleware - Generic type of middlewares supported by `Serverlessly` instance
  * @typeParam TProtocolServer - Generic type of `Protocol Server` capable of running a `Serverlessly` microservice on self-managed infrastructure
+ * @typeParam TProtocolServerProps - Generic type of options used to configure `Protocol Server`
  */
 export interface ServerlesslyProps<
   TProtocolContext,
   TMiddleware,
-  TProtocolServer
+  TProtocolServer,
+  TProtocolServerProps = undefined
 > {
   /**
    * Serverlessly `Protocol` which represents a network protocol like `http`
    */
-  protocol: Protocol<TProtocolContext, TMiddleware, TProtocolServer>;
+  protocol: Protocol<
+    TProtocolContext,
+    TMiddleware,
+    TProtocolServer,
+    TProtocolServerProps
+  >;
   /**
    * `Middleware Engine` which processes middlewares
    *
@@ -139,11 +148,13 @@ export interface HandlerProps<TProtocolContext, TPlatformHandler> {
  * @typeParam TProtocolContext - Generic type of `Protocol Context`
  * @typeParam TMiddleware - Generic type of middlewares supported by this microservice
  * @typeParam TProtocolServer - Generic type of `Protocol Server` capable of running a Serverlessly microservice on self-managed infrastructure
+ * @typeParam TProtocolServerProps - Generic type of options used to configure `Protocol Server`
  */
 export class Serverlessly<
   TProtocolContext,
   TMiddleware,
-  TProtocolServer
+  TProtocolServer,
+  TProtocolServerProps = undefined
 > extends EventEmitter {
   /**
    * `Middleware Engine` which processes middlewares
@@ -158,7 +169,8 @@ export class Serverlessly<
    */
   protected readonly protocolServerFactory: ProtocolServerFactory<
     TProtocolContext,
-    TProtocolServer
+    TProtocolServer,
+    TProtocolServerProps
   >;
 
   /**
@@ -183,7 +195,12 @@ export class Serverlessly<
    * ```
    */
   constructor(
-    props: ServerlesslyProps<TProtocolContext, TMiddleware, TProtocolServer>
+    props: ServerlesslyProps<
+      TProtocolContext,
+      TMiddleware,
+      TProtocolServer,
+      TProtocolServerProps
+    >
   ) {
     super();
     this.middlewareEngine =
@@ -264,6 +281,8 @@ export class Serverlessly<
 
   /**
    * Generates `Protocol Server` capable of running this Serverlessly microservice on self-managed infrastructure
+   * @typeParam TProtocolServerProps - Generic type of options used to configure `Protocol Server`
+   * @param props - Object used to configure `Protocol Server`
    * @returns `Protocol Server` e.g. HTTP Server, gRPC Server, Web Socket Server etc.
    *
    * @example
@@ -276,9 +295,9 @@ export class Serverlessly<
    *    });
    * ```
    */
-  getServer(): TProtocolServer {
+  getServer(props?: TProtocolServerProps): TProtocolServer {
     return this.getHandler({
-      platformAdapter: this.protocolServerFactory,
+      platformAdapter: this.protocolServerFactory(props),
     });
   }
 


### PR DESCRIPTION
<!-- Read Pull Request guideline: https://github.com/ServerlesslyStack/Serverlessly/blob/main/CONTRIBUTING.md#pull-request -->
<!-- Start by copying & pasting 🚧 (construction emoji) as a suffix of the title above (It'll indicate that work is in progress and PR won't be merged unless you want it). -->
<!-- Explain below what this Pull Request is all about. What's the motivation? What problem does it solve? -->

This Pull Request:

- edits `ProtocolServerFactory` to accept config objects as argument which can be used when creating protocol servers.
- edits `getServer()` of `Serverlessly` to accept config objects as argument which can be passed to `protocol.serverFactory`.
- coverts `Protocol` interface into class which can be further extended.

<!-- If this Pull Request fixes a bug, write "Fixes #123" without quotes where 123 is issue number. If an issue doesn't exist for the bug, create that first. -->
<!-- If this Pull Request implements a feature, write "Closes #123" without quotes where 123 is issue number. -->


<!-- If this Pull Request introduces BREAKING CHANGES, please uncomment the following line: -->
<!-- This PR introduces BREAKING CHANGES. -->

<!-- You must tick appropriate checkboxes below if applicable. To tick, replace [ ] with [x]. -->
- [x] I have read [CONTRIBUTING guide](../CONTRIBUTING.md).
- [x] I have added necessary tests.
- [x] I have added necessary docs.
- [x] I have run `yarn test && yarn lint && yarn format`.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
