### PR TITLE
feat(core): enforce Protocol Context to be function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ const eslintConfig = {
       ],
       rules: {
         'tsdoc/syntax': 'warn',
+        '@typescript-eslint/ban-types': 'off',
       },
     },
   ],

--- a/@serverlessly/core/__tests__/serverlessly.test.ts
+++ b/@serverlessly/core/__tests__/serverlessly.test.ts
@@ -218,15 +218,15 @@ describe('getHandler() Tests', () => {
   let getProtocolContextSpy: jest.SpyInstance<
     unknown,
     [
-      middlewareEngine: MiddlewareEngine<unknown, unknown>,
+      middlewareEngine: MiddlewareEngine<Function, unknown>,
       middlewares: unknown[]
     ]
   >;
   let getPlatformHandlerSpy: jest.SpyInstance<
     unknown,
     [
-      platformAdapter: PlatformAdapter<unknown, unknown>,
-      hydratedProtocol: unknown
+      platformAdapter: PlatformAdapter<Function, unknown>,
+      protocolContext: Function
     ]
   >;
 

--- a/@serverlessly/core/lib/helpers/platform-handler.ts
+++ b/@serverlessly/core/lib/helpers/platform-handler.ts
@@ -1,6 +1,9 @@
 import { PlatformAdapter } from '../platform-adapter';
 
-export function getPlatformHandler<TProtocolContext, TPlatformHandler>(
+export function getPlatformHandler<
+  TProtocolContext extends Function,
+  TPlatformHandler
+>(
   platformAdapter: PlatformAdapter<TProtocolContext, TPlatformHandler>,
   protocolContext: TProtocolContext
 ): TPlatformHandler {

--- a/@serverlessly/core/lib/helpers/protocol-context.ts
+++ b/@serverlessly/core/lib/helpers/protocol-context.ts
@@ -1,6 +1,9 @@
 import { MiddlewareEngine } from '../middleware-engine';
 
-export function getProtocolContext<TProtocolContext, TMiddleware>(
+export function getProtocolContext<
+  TProtocolContext extends Function,
+  TMiddleware
+>(
   middlewareEngine: MiddlewareEngine<TProtocolContext, TMiddleware>,
   middlewares: TMiddleware[]
 ): TProtocolContext {

--- a/@serverlessly/core/lib/middleware-engine.ts
+++ b/@serverlessly/core/lib/middleware-engine.ts
@@ -6,6 +6,6 @@
  * @remarks
  * A new `Middleware Engine` needs to adhere to this type alias
  */
-export type MiddlewareEngine<TProtocolContext, TMiddleware> = (
+export type MiddlewareEngine<TProtocolContext extends Function, TMiddleware> = (
   middlewares: TMiddleware[]
 ) => TProtocolContext;

--- a/@serverlessly/core/lib/platform-adapter.ts
+++ b/@serverlessly/core/lib/platform-adapter.ts
@@ -6,6 +6,7 @@
  * @remarks
  * A new `Platform Adapter` needs to adhere to this type alias
  */
-export type PlatformAdapter<TProtocolContext, TPlatformHandler> = (
-  protocolContext: TProtocolContext
-) => TPlatformHandler;
+export type PlatformAdapter<
+  TProtocolContext extends Function,
+  TPlatformHandler
+> = (protocolContext: TProtocolContext) => TPlatformHandler;

--- a/@serverlessly/core/lib/protocol.ts
+++ b/@serverlessly/core/lib/protocol.ts
@@ -8,7 +8,7 @@ import { PlatformAdapter } from './platform-adapter';
  * @typeParam TProtocolServerProps - Optional generic type of options used to configure `Protocol Server`
  */
 export type ProtocolServerFactory<
-  TProtocolContext,
+  TProtocolContext extends Function,
   TProtocolServer,
   TProtocolServerProps = undefined
 > = (
@@ -23,7 +23,7 @@ export type ProtocolServerFactory<
  * @typeParam TProtocolServerProps - Optional generic type of options used to configure `Protocol Server`
  */
 export class Protocol<
-  TProtocolContext,
+  TProtocolContext extends Function,
   TMiddleware,
   TProtocolServer,
   TProtocolServerProps = undefined
@@ -80,16 +80,15 @@ export class Protocol<
  * An implementation is already available with `protocolServerAdapter`.
  * No need to implement this unless the user has not control over custom `Protocol Server` for which so code needs to be injected.
  */
-export type ProtocolServerAdapter<TProtocolContext> = PlatformAdapter<
-  TProtocolContext,
-  TProtocolContext
->;
+export type ProtocolServerAdapter<
+  TProtocolContext extends Function
+> = PlatformAdapter<TProtocolContext, TProtocolContext>;
 
 /**
  * `Platform Adapter` meant for `Protocol Server` platform
  * @param protocolContext - `Protocol Context`
  * @returns `Protocol Context` without any change
  */
-export const protocolServerAdapter: ProtocolServerAdapter<unknown> = (
+export const protocolServerAdapter: ProtocolServerAdapter<Function> = (
   protocolContext
 ) => protocolContext;

--- a/@serverlessly/core/lib/serverlessly.ts
+++ b/@serverlessly/core/lib/serverlessly.ts
@@ -17,7 +17,7 @@ type ServerlesslyMiddlewaresEvent = 'MIDDLEWARES' | 'NEW_MIDDLEWARES';
 
 export interface Serverlessly<
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  TProtocolContext,
+  TProtocolContext extends Function,
   TMiddleware,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   TProtocolServer,
@@ -109,7 +109,7 @@ export interface Serverlessly<
  * @typeParam TProtocolServerProps - Generic type of options used to configure `Protocol Server`
  */
 export interface ServerlesslyProps<
-  TProtocolContext,
+  TProtocolContext extends Function,
   TMiddleware,
   TProtocolServer,
   TProtocolServerProps = undefined
@@ -136,7 +136,10 @@ export interface ServerlesslyProps<
  * @typeParam TProtocolContext - Generic type of `Protocol Context`
  * @typeParam TPlatformHandler - Generic type of handler returned by `getHandler()`
  */
-export interface HandlerProps<TProtocolContext, TPlatformHandler> {
+export interface HandlerProps<
+  TProtocolContext extends Function,
+  TPlatformHandler
+> {
   /**
    * `Platform Adapter` which makes it possible to run a Serverlessly microservice on a specific platform like `AWS Lambda`
    */
@@ -151,7 +154,7 @@ export interface HandlerProps<TProtocolContext, TPlatformHandler> {
  * @typeParam TProtocolServerProps - Generic type of options used to configure `Protocol Server`
  */
 export class Serverlessly<
-  TProtocolContext,
+  TProtocolContext extends Function,
   TMiddleware,
   TProtocolServer,
   TProtocolServerProps = undefined
@@ -308,7 +311,7 @@ export class Serverlessly<
   getProtocolContext(): TProtocolContext {
     return this.getHandler({
       platformAdapter: <ProtocolServerAdapter<TProtocolContext>>(
-        protocolServerAdapter
+        (<unknown>protocolServerAdapter)
       ),
     });
   }


### PR DESCRIPTION
<!-- Read Pull Request guideline: https://github.com/ServerlesslyStack/Serverlessly/blob/main/CONTRIBUTING.md#pull-request -->
<!-- Start by copying & pasting 🚧 (construction emoji) as a suffix of the title above (It'll indicate that work is in progress and PR won't be merged unless you want it). -->
<!-- Explain below what this Pull Request is all about. What's the motivation? What problem does it solve? -->

This PR constraints `Protocol Context` generics to be a `Function`.

<!-- If this Pull Request fixes a bug, write "Fixes #123" without quotes where 123 is issue number. If an issue doesn't exist for the bug, create that first. -->
<!-- If this Pull Request implements a feature, write "Closes #123" without quotes where 123 is issue number. -->


<!-- If this Pull Request introduces BREAKING CHANGES, please uncomment the following line: -->
<!-- This PR introduces BREAKING CHANGES. -->

<!-- You must tick appropriate checkboxes below if applicable. To tick, replace [ ] with [x]. -->
- [x] I have read [CONTRIBUTING guide](../CONTRIBUTING.md).
- [x] I have added necessary tests.
- [ ] ~~I have added necessary docs.~~
- [x] I have run `yarn test && yarn lint && yarn format`.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
